### PR TITLE
Feat: 유저 전시이름 변경 API 구현

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+
 import { AppService } from './app.service';
 
 @Controller()

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,9 @@
-import { Module } from '@nestjs/common';
-import { APP_INTERCEPTOR } from '@nestjs/core';
 import { MorganInterceptor, MorganModule } from 'nest-morgan';
+
+import { APP_INTERCEPTOR } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from './modules/user/user.module';
 

--- a/src/modules/user/dto/create-user.dto.ts
+++ b/src/modules/user/dto/create-user.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional, IsString, Length } from 'class-validator';
 
 export class CreateUserDto {
   @IsEmail()
@@ -14,5 +14,6 @@ export class CreateUserDto {
   readonly name: string;
 
   @IsOptional()
+  @Length(2,10)
   readonly displayed_name: string;
 }

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { CreateUserDto } from "./create-user.dto";
+import { PickType } from "@nestjs/swagger";
+
+export class UpdateUserDto extends PickType(CreateUserDto, ['email', 'displayed_name'] as const){}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,18 +1,26 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Patch, Post } from '@nestjs/common';
 import { ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UserService } from './user.service';
 import { User } from '../../entities/user.entity';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Controller('user')
 @ApiTags('User API')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @Post('/register')
+  @Post()
   @ApiOperation({ summary: 'Create User API', description: 'Create User' })
   @ApiCreatedResponse({ description: 'Create User', type: User })
   register(@Body() userData: CreateUserDto) {
     return this.userService.register(userData);
+  }
+
+  @Patch()
+  @ApiOperation({ summary: 'Update User API', description: 'Update displayed name of user' })
+  @ApiCreatedResponse({ description: 'Update displayed name of user', type: User })
+  updateDisplayedName(@Body() updateUserData: UpdateUserDto){
+    return this.userService.updateDisplayedNameByEmail(updateUserData.email, updateUserData.displayed_name);
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -4,15 +4,12 @@ import { User } from 'src/entities/user.entity';
 import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import * as bcrypt from 'bcrypt';
-import { Connection } from 'typeorm';
 
 @Injectable()
 export class UserService {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
-
-    private connection: Connection,
   ) {}
 
   async register(userData: CreateUserDto): Promise<User> {
@@ -26,6 +23,12 @@ export class UserService {
       displayed_name,
     });
     user.password = hashedPassword;
+    return await this.userRepository.save(user);
+  }
+
+  async updateDisplayedNameByEmail(email: string, displayed_name: string): Promise<User>{
+    const user= await this.userRepository.findOne({email: email});
+    user.displayed_name= displayed_name;
     return await this.userRepository.save(user);
   }
 }


### PR DESCRIPTION
Patch 메서드를 사용해 유저 전시이름 변경
기존 회원가입 API URL 수정 @Post("/register") -> @Post()
CreateUserDto의 displayed_name 속성에 길이 제한 검사 추가